### PR TITLE
Add handling if a reading list URL returns a full HTML document instead of a partial

### DIFF
--- a/dist/jquery.reading-list.js
+++ b/dist/jquery.reading-list.js
@@ -19,6 +19,7 @@ var events = {
   atTop: 'reading-list-at-top',
   itemLoadStart: 'reading-list-item-load-start',
   itemLoadFinish: 'reading-list-item-load-done',
+  itemLoadError: 'reading-list-item-load-error',
   itemLookingIn: 'reading-list-item-in-looking',
   itemLookingOut: 'reading-list-item-out-looking',
   itemProgress: 'reading-list-item-progress',
@@ -604,7 +605,8 @@ ReadingList.prototype.retrieveListItem = function ($readingListItem) {
   var html;
   var status;
   var self = this;
-  return $.get($readingListItem.data('href'))
+  var partialUrl = $readingListItem.data('href');
+  return $.get(partialUrl)
     .done(function (data) {
       html = self.settings.dataRetrievalSuccess($readingListItem, data);
       status = loadStatus.LOADED;
@@ -623,6 +625,13 @@ ReadingList.prototype.retrieveListItem = function ($readingListItem) {
       $readingListItem.data('loadStatus', status);
 
       try {
+        if (html.startsWith('<!DOCTYPE html>') || html.startsWith('<html>')) {
+          $readingListItem.html('');
+          self._doItemEvent(events.itemLoadError, $readingListItem, { errorMsg: 'URL returned full document, instead of partial: ' + partialUrl }, true);
+          // Still fire finish event so the reading list moves on with the next item
+          self._doItemEvent(events.itemLoadFinish, $readingListItem, true);
+          return;
+        }
         $readingListItem.html(html);
       }
       catch (error) {

--- a/src/jquery.reading-list.js
+++ b/src/jquery.reading-list.js
@@ -19,6 +19,7 @@ var events = {
   atTop: 'reading-list-at-top',
   itemLoadStart: 'reading-list-item-load-start',
   itemLoadFinish: 'reading-list-item-load-done',
+  itemLoadError: 'reading-list-item-load-error',
   itemLookingIn: 'reading-list-item-in-looking',
   itemLookingOut: 'reading-list-item-out-looking',
   itemProgress: 'reading-list-item-progress',
@@ -604,7 +605,8 @@ ReadingList.prototype.retrieveListItem = function ($readingListItem) {
   var html;
   var status;
   var self = this;
-  return $.get($readingListItem.data('href'))
+  var partialUrl = $readingListItem.data('href');
+  return $.get(partialUrl)
     .done(function (data) {
       html = self.settings.dataRetrievalSuccess($readingListItem, data);
       status = loadStatus.LOADED;
@@ -623,6 +625,13 @@ ReadingList.prototype.retrieveListItem = function ($readingListItem) {
       $readingListItem.data('loadStatus', status);
 
       try {
+        if (html.startsWith('<!DOCTYPE html>') || html.startsWith('<html>')) {
+          $readingListItem.html('');
+          self._doItemEvent(events.itemLoadError, $readingListItem, { errorMsg: 'URL returned full document, instead of partial: ' + partialUrl }, true);
+          // Still fire finish event so the reading list moves on with the next item
+          self._doItemEvent(events.itemLoadFinish, $readingListItem, true);
+          return;
+        }
         $readingListItem.html(html);
       }
       catch (error) {


### PR DESCRIPTION
@collin @mparent61 @MelizzaP @MichaelButkovic @benghaziboy 

This will address the screen going white if the reading list loads in a full HTML document.  If you're setting the html `$readingListItem.html(html);` and the html is a full document, it wipes the entire existing html doc.

